### PR TITLE
chore: use moksha 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,8 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "moksha-core"
-version = "0.1.0"
-source = "git+https://github.com/ngutech21/moksha.git?branch=master#6612e491019535c6c46d099042560fbb4c7165e1"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1f9af10be82ae519e9a056cf47ee6d45388edd04ebb9ebaf15f7c025d6757e"
 dependencies = [
  "anyhow",
  "base64 0.21.2",
@@ -2078,18 +2079,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2131,9 +2132,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
+checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
 dependencies = [
  "base64 0.21.2",
  "chrono",
@@ -2148,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
+checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,5 @@ tower = "0.4.13"
 futures-util = "0.3.28"
 data-encoding = "2.4.0"
 base64-url = "2.0.0"
-moksha-core = { git = "https://github.com/ngutech21/moksha.git", branch = "master" }
+moksha-core = "0.1.2"
 http = "0.2.9"


### PR DESCRIPTION
Use moksha 0.1.2 from crates.io instead of using the master-branch